### PR TITLE
Injection prevention

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild

--- a/src-tauri/src/audio_splitter.rs
+++ b/src-tauri/src/audio_splitter.rs
@@ -6,7 +6,7 @@ use wav_splitter::minutes_to_duration as wav_minutes_to_duration;
 use wav_splitter::split_wav;
 use wav_splitter::SplitOptions as WavSplitOptions;
 
-/// Ce fichier contient la logique de découpage des fichiers audio  en chunks.
+/// Ce fichier contient la logique de découpage des fichiers audio en chunks.
 /// Il utilise les bibliothèques mp3_splitter et wav_splitter pour effectuer le découpage.
 /// Il stocke les fichiers chunks dans un répertoire spécifique dans le dossier de téléchargement de l'utilisateur.
 
@@ -31,9 +31,12 @@ pub fn split_audio_file(
         Some(ext) => ext.to_str().unwrap_or(""),
         None => "",
     };
+
     let file_extension = file_extension.to_lowercase();
     let file_extension = file_extension.trim_start_matches('.');
+
     println!("File extension: {}", file_extension);
+
     // stockage des chemins des fichiers créés
     let mut chunk_paths: Vec<String> = vec![];
 
@@ -130,32 +133,99 @@ pub fn clear_chunks() -> Result<(), String> {
     }
 }
 
-/// Sanitizes a filename by removing invalid char and replacing path separators
-// Removes all non-alphanumeric characters except _, -, and .
-// Replaces path separators (/ and \) with underscores
-// Ensures a minimum length of 4 characters ("chunk")
-// Limits maximum length to 255 characters
+/// Sanitizes a filename by removing invalid chars and replacing path separators
+/// - Replaces path separators (/ and \) with underscores
+/// - Replaces other invalid characters with dots
+/// - Collapses consecutive dots
+/// - Ensures a minimum length of 4 characters ("chunk")
+/// - Limits maximum length to 255 characters
 fn sanitize_filename(input: &str) -> String {
     let mut sanitized = String::with_capacity(input.len());
+    let mut last_char: Option<char> = None;
 
-    // Allow alphanumeric, underscore, hyphen, and period
     for c in input.chars() {
-        if c.is_alphanumeric() || c == '_' || c == '-' || c == '.' {
-            sanitized.push(c);
+        // Determine the replacement character
+        let processed = if c.is_alphanumeric() || c == '_' || c == '-' || c == '.' {
+            // Keep valid characters as-is
+            c
+        } else if c == '/' || c == '\\' {
+            // Replace path separators with underscore
+            '_'
+        } else {
+            // Replace other invalid characters with dot
+            '.'
+        };
+
+        // Collapse consecutive dots
+        if processed == '.' && last_char == Some('.') {
+            continue;
         }
-        // Replace path separators with underscore
-        else if c == '/' || c == '\\' {
-            sanitized.push('_');
-        }
+
+        sanitized.push(processed);
+        last_char = Some(processed);
     }
 
-    // Truncate to reasonable length : 255 chars bro, enough
-    sanitized.truncate(255);
+    // Trim trailing dots and underscores
+    let trimmed = sanitized.trim_end_matches(|c| c == '.' || c == '_');
 
-    // Ensure it's not empty
-    if sanitized.is_empty() {
-        sanitized.push_str("chunk");
+    // Handle empty results
+    let mut result = if trimmed.is_empty() {
+        "chunk".to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    // Truncate to max 255 chars
+    result.truncate(255);
+    result
+}
+
+/// Tests for the sanitize_filename function
+#[cfg(test)]
+mod albert_tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_filename() {
+        // Basic valid filename stays the same
+        assert_eq!(sanitize_filename("valid_name"), "valid_name");
+
+        // Invalid characters are replaced with dots
+        assert_eq!(
+            sanitize_filename("file:name*with?invalid<chars"),
+            "file.name.with.invalid.chars"
+        );
+
+        // Empty input becomes "chunk"
+        assert_eq!(sanitize_filename(""), "chunk");
+
+        // Very long names are truncated to 255 chars
+        assert_eq!(sanitize_filename(&"a".repeat(300)), "a".repeat(255));
+
+        // Folder separators become underscores
+        assert_eq!(sanitize_filename("folder/file"), "folder_file");
+        assert_eq!(sanitize_filename("folder\\file"), "folder_file");
+
+        // Consecutive dots are collapsed
+        assert_eq!(sanitize_filename("file....name"), "file.name");
+
+        // Leading dots are preserved (important for security)
+        assert_eq!(sanitize_filename(".hidden"), ".hidden");
+
+        // Trailing dots are trimmed
+        assert_eq!(sanitize_filename("filename..."), "filename");
+
+        // Leading and trailing underscores: leading preserved, trailing trimmed
+        assert_eq!(sanitize_filename("_filename_"), "_filename");
+
+        // All invalid chars becomes "chunk" after trimming
+        assert_eq!(sanitize_filename("///\\\\:::"), "chunk");
+
+        // Unicode characters are handled properly
+        assert_eq!(sanitize_filename("résumé.pdf"), "résumé.pdf");
+        assert_eq!(sanitize_filename("файл.txt"), "файл.txt");
+
+        // Mixed path separators
+        assert_eq!(sanitize_filename("path/to\\file"), "path_to_file");
     }
-
-    sanitized
 }

--- a/src-tauri/src/audio_splitter.rs
+++ b/src-tauri/src/audio_splitter.rs
@@ -27,13 +27,11 @@ pub fn split_audio_file(
         .map_err(|e| format!("Failed to create chunk directory: {}", e))?;
 
     // Check if the file is a WAV or MP3 file
-    let file_extension = match Path::new(file_path).extension() {
-        Some(ext) => ext.to_str().unwrap_or(""),
-        None => "",
-    };
-
-    let file_extension = file_extension.to_lowercase();
-    let file_extension = file_extension.trim_start_matches('.');
+    let file_extension = Path::new(file_path)
+    .extension()
+    .and_then(|ext| ext.to_str())
+    .unwrap_or("")
+    .to_lowercase();
 
     println!("File extension: {}", file_extension);
 

--- a/src-tauri/src/audio_splitter.rs
+++ b/src-tauri/src/audio_splitter.rs
@@ -36,7 +36,7 @@ pub fn split_audio_file(
     println!("File extension: {}", file_extension);
 
     // stockage des chemins des fichiers créés
-    let mut chunk_paths: Vec<String> = vec![];
+    let mut chunk_paths: Vec<String> = Vec::with_capacity(10); 
 
     // Determine the split options based on the file type
     if file_extension == "mp3" {

--- a/src-tauri/src/audio_transcriber.rs
+++ b/src-tauri/src/audio_transcriber.rs
@@ -5,31 +5,20 @@ pub async fn transcribe_chunk(path: String, use_system_proxy: bool, language: Op
     println!("Starting transcription for: {} in language: {}", path, language.as_deref().unwrap_or("fr"));
 
     let output_file = format!("{}.json", path);
-    
-    // Set the language to French if none is provided
     let lang = language.unwrap_or_else(|| "fr".to_string());
     
-    // Call the async transcription function directly without spawning a thread
-    match transcribe_audio_async(&path, &output_file, use_system_proxy, &lang).await {
-        Ok(_) => {
-            println!("Transcription completed successfully for: {}", path);
-            // Format the transcription into a readable text file
-            match format_transcription_file(output_file.clone()) {
-                Ok(formatted_path) => {
-                    println!("Transcription formatted successfully: {}", formatted_path);
-                    Ok(formatted_path)
-                }
-                Err(e) => {
-                    eprintln!("Error formatting transcription: {}", e);
-                    Err(format!("Error formatting transcription: {}", e))
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("Error during transcription: {} for {}", e, path);
-            Err(format!("Error during transcription: {} for {}", e, path))
-        }
-    }
+    // Use ? operator to propagate errors
+    transcribe_audio_async(&path, &output_file, use_system_proxy, &lang)
+        .await
+        .map_err(|e| format!("Error during transcription: {} for {}", e, path))?;
+        
+    println!("Transcription completed successfully for: {}", path);
+    
+    // Format the transcription
+    let formatted_path = format_transcription_file(output_file)?;
+    println!("Transcription formatted successfully: {}", formatted_path);
+    
+    Ok(formatted_path)
 }
 
 pub fn format_transcription_file(path: String) -> Result<String, String> {

--- a/src/style.css
+++ b/src/style.css
@@ -104,7 +104,7 @@ button:disabled {
 .file-path-display {
   margin-top: 1rem;
   padding: 0.5rem;
-  background-color: #f5f5f5;
+  background-color: #969696;
   border-radius: 4px;
   min-height: 2rem;
 }


### PR DESCRIPTION
- Sécurité : création d'une fonction `sanitize_filename()` à vocation de nettoyage du nom de fichier afin d'éviter une injection ou un crash
- Tests : ajout de tests unitaire via cargo, sur `sanitize_filename()`
- Gestion mémoire : fixe une valeur arbitraire à 10 pour `Vec<String>` afin d'éviter la réallocation multiple. Pas certain que 10 soit suffisant. (https://github.com/jbousquie/albert/pull/7/commits/8e3777e591e1bc41b95fd70c711c4144d0bbbb1e)
- UI : changement de la couleur de fond pour plus foncée (zone du fichier sélectionné) : blanc par défaut, si le mode sombre est activé cette zone est illisible.
- Quelques simplifications de code