### PR TITLE
ajout envoi d'un label pour le format : "audio de x à y minutes"

### DIFF
--- a/src-tauri/src/audio_transcriber.rs
+++ b/src-tauri/src/audio_transcriber.rs
@@ -4,7 +4,7 @@ use transcription_albert::{format_transcription, transcribe_audio_async};
 
 /// Transcribe a chunk of audio
 /// Returns the path to the transcription file after formatting in Ok(String)
-pub async fn transcribe_chunk(path: String, use_system_proxy: bool, language: Option<String>) -> Result<String, String> {
+pub async fn transcribe_chunk(path: String, use_system_proxy: bool, language: Option<String>, label: Option<String>) -> Result<String, String> {
     println!("Starting transcription for: {} in language: {}", path, language.as_deref().unwrap_or("fr"));
 
     let output_file = format!("{}.json", path);
@@ -18,7 +18,7 @@ pub async fn transcribe_chunk(path: String, use_system_proxy: bool, language: Op
     println!("Transcription completed successfully for: {}", path);
     
     // Format the transcription
-    let formatted_path = format_transcription_file(output_file)?;
+    let formatted_path = format_transcription_file(output_file, label)?;
     println!("Transcription formatted successfully: {}", formatted_path);
     
     Ok(formatted_path)
@@ -26,7 +26,7 @@ pub async fn transcribe_chunk(path: String, use_system_proxy: bool, language: Op
 
 
 // Returns the path of the formatted transcription file in Ok(String)
-pub fn format_transcription_file(path: String) -> Result<String, String> {
+pub fn format_transcription_file(path: String, label: Option<String>) -> Result<String, String> {
     let trscr_dir = crate::get_transcription_directory()?;
     let filename = Path::new(&path).file_name().unwrap(); // on est sûr ici que le nom de fichier est valide
     let cleared_filename = filename
@@ -35,9 +35,7 @@ pub fn format_transcription_file(path: String) -> Result<String, String> {
         .replace(".json", "")
         .replace(".wav", "")
         .replace(".mp3", "");
-
     let output_file = format!("{}/{}.txt", trscr_dir.display(), cleared_filename);
-    format_transcription(&path, &output_file);
-
+    format_transcription(&path, &output_file, label.as_deref());
     Ok(output_file)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,9 +50,9 @@ async fn split_file(
 
 // / Sends a chunk for transcription to Albert
 #[tauri::command(rename_all = "snake_case")]
-async fn send_chunk(path: String, use_system_proxy: bool, language: Option<String>) -> Result<String, String> {
+async fn send_chunk(path: String, use_system_proxy: bool, language: Option<String>, label: Option<String>) -> Result<String, String> {
     // Call the transcribe_chunk function from audio_transcriber
-    let transcription = transcribe_chunk(path, use_system_proxy, language).await?;
+    let transcription = transcribe_chunk(path, use_system_proxy, language, label).await?;
     Ok(transcription)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -430,7 +430,7 @@ function send_chunks(chunks: string[], chunkDuration: number) {
   let minutes = Math.floor(duration);
   let seconds = Math.round((duration - minutes) * 60);
   
-  logMessage('<br>Envoi des ' + length.toString() + ' morceaux successivement à Albert pour transcription.<br>Cette opération peut durer jusqu`à plus d\'une minute par morceau.<br>Durée totale maximum estimée à environ <b>' + minutes.toString() + '\' ' + ('0' + seconds.toString()).slice(-2) + '"</b><br>Merci de patienter...<br><br>');
+  logMessage('<br>Envoi des ' + length.toString() + ' morceaux successivement à Albert pour transcription.<br>Durée totale <i>maximum</i> estimée à environ <b>' + minutes.toString() + '\' ' + ('0' + seconds.toString()).slice(-2) + '"</b><br>Merci de patienter...<br><br>');
   
   // Process chunks sequentially with their respective delays
   processChunksSequentially(chunks, 0, 0);
@@ -453,12 +453,14 @@ async function processChunksSequentially(chunks: string[], index: number, errors
   }
   
   const path = chunks[index];
+  const label = "Audio de " + (index * chunkDuration).toString() + " à " + ((index + 1) * chunkDuration).toString() + " minutes";
   
   // response is the formatted transcription file path
   const response = await invoke<string>('send_chunk', { 
     path, 
     use_system_proxy: useSystemProxy,
-    language: transcriptionLanguage
+    language: transcriptionLanguage,
+    label: label
   })
   .then((response) => {
       // Check for cancellation again after processing
@@ -497,7 +499,7 @@ function terminate(errors: number) {
   let submitButton = document.getElementById('file-submit-button') as HTMLButtonElement;
   let cancelButton = document.getElementById('file-cancel-button') as HTMLButtonElement;
   lastSessionName = sessionNameInput.value;
-  sessionNameInput.value = '';
+  if (!isCancelled) { sessionNameInput.value = '' } else { sessionNameInput.focus(); };
   filePathDisplay.innerHTML = 'Aucun fichier sélectionné';
   
   invoke<string>('terminate_transcription', { cancelled: isCancelled })


### PR DESCRIPTION
on peut envoyer un label (un string avec des valeurs) pour l'entête de chaque morceau transcrit
exemple : "audio de 10 à 20 minutes"